### PR TITLE
feat: add `Boundary.from_delimiter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 
 - update ACRONYM to correctly identify acronym boundaries ([`dd604b0`](https://github.com/zobweyt/textcase/commit/dd604b0725329ae71be2212e694087216d57d388))
 
+### <!-- 1 -->Features <!-- omit in toc -->
+
+- add `Boundary.from_delimiter` ([`079dc33`](https://github.com/zobweyt/textcase/commit/079dc330a1c2dc131a1347da5f210bf558bf2cbb))
+
+### <!-- 3 -->Refactoring <!-- omit in toc -->
+
+- update `UNDERSCORE`, `HYPEN`, and `SPACE` to use `Boundary.from_delimiter` ([`42e65f5`](https://github.com/zobweyt/textcase/commit/42e65f5b96c2ebc07b458c5f5e274dacb1733648))
+
+### <!-- 4 -->Testing <!-- omit in toc -->
+
+- update custom boundary tests to use `Boundary.from_delimiter` ([`705296f`](https://github.com/zobweyt/textcase/commit/705296fcdc322fc18e3d24534b775cf0a7e79da2))
+
 ## [0.2.2](https://github.com/zobweyt/textcase/compare/0.2.1...0.2.2) (2025-04-12)
 
 Performance and documentation enhancements

--- a/docs/.snippets/boundaries/custom.py
+++ b/docs/.snippets/boundaries/custom.py
@@ -4,13 +4,8 @@ from textcase.boundary import Boundary
 # Not quite what we want
 print(convert("coolers.revenge", case.TITLE))
 
-# Define custom boundary
-DOT = Boundary(
-    satisfies=lambda text: text.startswith("."),
-    length=1,
-)
-
-print(convert("coolers.revenge", case.TITLE, (DOT,)))
+# Use custom boundary
+print(convert("coolers.revenge", case.TITLE, (Boundary.from_delimiter("."),)))
 
 # Define complex custom boundary
 AT_LETTER = Boundary(

--- a/docs/en/learn/boundaries.md
+++ b/docs/en/learn/boundaries.md
@@ -14,7 +14,7 @@ Say a string has the word `2D`, such as `scale2D`. No exclusive usage of [`conve
 
 This library provides [a number of constants for boundaries associated with common cases][textcase.boundary]. But you can create your own boundary to split on other criteria:
 
-```python exec="true" source="tabbed-left" tabs="custom.py|output.txt" result="txt" hl_lines="8-11 16-20"
+```python exec="true" source="tabbed-left" tabs="custom.py|output.txt" result="txt" hl_lines="8 11-15"
 --8<-- "docs/.snippets/boundaries/custom.py"
 ```
 

--- a/docs/ru/learn/boundaries.md
+++ b/docs/ru/learn/boundaries.md
@@ -14,7 +14,7 @@
 
 Эта библиотека предоставляет [ряд констант для границ][textcase.boundary], связанных с общими случаями. Но вы можете создать свою собственную границу для разбиения по другим критериям:
 
-```python exec="true" source="tabbed-left" tabs="custom.py|output.txt" result="txt" hl_lines="8-11 16-20"
+```python exec="true" source="tabbed-left" tabs="custom.py|output.txt" result="txt" hl_lines="8 11-15"
 --8<-- "docs/.snippets/boundaries/custom.py"
 ```
 

--- a/tests/boundary/test_custom.py
+++ b/tests/boundary/test_custom.py
@@ -2,16 +2,11 @@ from textcase import case, convert
 from textcase.boundary import Boundary
 
 
-def test_custom_simple_boundary() -> None:
-    DOT = Boundary(
-        satisfies=lambda text: text.startswith("."),
-        length=1,
-    )
-
-    assert convert("coolers.revenge", case.TITLE, (DOT,)) == "Coolers Revenge"
+def test_boundary_from_delimiter() -> None:
+    assert convert("coolers.revenge", case.TITLE, (Boundary.from_delimiter("."),)) == "Coolers Revenge"
 
 
-def test_custom_complex_boundary() -> None:
+def test_boundary_init() -> None:
     AT_LETTER = Boundary(
         satisfies=lambda text: (len(text) > 1 and text[0] == "@") and (text[1] == text[1].lower()),
         start=1,

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -63,6 +63,30 @@ class Boundary:
     **Added in version:** [`0.2.0`](https://zobweyt.github.io/textcase/changelog/#020-2025-04-01)
     """
 
+    @staticmethod
+    def from_delimiter(delimiter: str) -> "Boundary":
+        """Create a new [`Boundary`][textcase.boundary.Boundary] instance from a delimiter string.
+
+        **Unreleased.**
+
+        Args:
+            delimiter: A string to be used as the delimiter for creating the boundary.
+
+        Returns:
+            A new [`Boundary`][textcase.boundary.Boundary] instance, configured to match the provided delimiter.
+
+        Examples:
+            >>> Boundary.from_delimiter("_").start
+            0
+
+            >>> Boundary.from_delimiter("_").length
+            1
+        """
+        return Boundary(
+            satisfies=lambda text: text[:1] == delimiter,
+            length=len(delimiter),
+        )
+
 
 UNDERSCORE: Final[Boundary] = Boundary(
     satisfies=lambda text: text[:1] == "_",

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -67,6 +67,10 @@ class Boundary:
     def from_delimiter(delimiter: str) -> "Boundary":
         """Create a new [`Boundary`][textcase.boundary.Boundary] instance from a delimiter string.
 
+        This is a helper method that can be used to create simple boundaries such as
+        [`UNDERSCORE`][textcase.boundary.UNDERSCORE], [`HYPHEN`][textcase.boundary.HYPHEN],
+        or [`SPACE`][textcase.boundary.SPACE].
+
         **Unreleased.**
 
         Args:

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -88,28 +88,19 @@ class Boundary:
         )
 
 
-UNDERSCORE: Final[Boundary] = Boundary(
-    satisfies=lambda text: text[:1] == "_",
-    length=1,
-)
+UNDERSCORE: Final[Boundary] = Boundary.from_delimiter("_")
 """Splits on `_`, consuming the character on segmentation.
 
 **Added in version:** [`0.2.0`](https://zobweyt.github.io/textcase/changelog/#020-2025-04-01)
 """
 
-HYPHEN: Final[Boundary] = Boundary(
-    satisfies=lambda text: text[:1] == "-",
-    length=1,
-)
+HYPHEN: Final[Boundary] = Boundary.from_delimiter("-")
 """Splits on `-`, consuming the character on segmentation.
 
 **Added in version:** [`0.2.0`](https://zobweyt.github.io/textcase/changelog/#020-2025-04-01)
 """
 
-SPACE: Final[Boundary] = Boundary(
-    satisfies=lambda text: text[:1] == " ",
-    length=1,
-)
+SPACE: Final[Boundary] = Boundary.from_delimiter(" ")
 """Splits on space, consuming the character on segmentation.
 
 **Added in version:** [`0.2.0`](https://zobweyt.github.io/textcase/changelog/#020-2025-04-01)


### PR DESCRIPTION
### Description

This PR adds a new `Boundary.from_delimiter` static method to simplify the creation of simple boundaries from a delimiter string.

### Changes

#### Features <!-- omit in toc -->

- add `Boundary.from_delimiter` ([`079dc33`](https://github.com/zobweyt/textcase/commit/079dc330a1c2dc131a1347da5f210bf558bf2cbb))

#### Refactoring <!-- omit in toc -->

- update `UNDERSCORE`, `HYPEN`, and `SPACE` to use `Boundary.from_delimiter` ([`42e65f5`](https://github.com/zobweyt/textcase/commit/42e65f5b96c2ebc07b458c5f5e274dacb1733648))

#### Testing <!-- omit in toc -->

- update custom boundary tests to use `Boundary.from_delimiter` ([`705296f`](https://github.com/zobweyt/textcase/commit/705296fcdc322fc18e3d24534b775cf0a7e79da2))


### Related

- Closes #4
