### PR TITLE
feat: add `INTERPUNCT` boundary and `MIDDOT` case

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ from textcase import case, convert
 print(convert("ronnie james dio", case.SNAKE))     # ronnie_james_dio
 print(convert("Ronnie_James_dio", case.CONSTANT))  # RONNIE_JAMES_DIO
 print(convert("RONNIE_JAMES_DIO", case.KEBAB))     # ronnie-james-dio
+print(convert("ronnie james dio", case.MIDDOT))    # ronnie·james·dio
 print(convert("RONNIE-JAMES-DIO", case.CAMEL))     # ronnieJamesDio
 print(convert("ronnie-james-dio", case.PASCAL))    # RonnieJamesDio
 print(convert("RONNIE JAMES DIO", case.LOWER))     # ronnie james dio

--- a/docs/.snippets/index/convert.py
+++ b/docs/.snippets/index/convert.py
@@ -3,6 +3,7 @@ from textcase import case, convert
 print(convert("ronnie james dio", case.SNAKE))
 print(convert("Ronnie_James_dio", case.CONSTANT))
 print(convert("RONNIE_JAMES_DIO", case.KEBAB))
+print(convert("ronnie james dio", case.MIDDOT))
 print(convert("RONNIE-JAMES-DIO", case.CAMEL))
 print(convert("ronnie-james-dio", case.PASCAL))
 print(convert("RONNIE JAMES DIO", case.LOWER))

--- a/tests/boundary/test_boundaries.py
+++ b/tests/boundary/test_boundaries.py
@@ -13,6 +13,10 @@ def test_space() -> None:
     assert (boundary.SPACE,) == tuple(boundary.get_boundaries(" "))
 
 
+def test_interpunct() -> None:
+    assert 0 == len(tuple(boundary.get_boundaries("·")))
+
+
 def test_lower_upper() -> None:
     assert (boundary.LOWER_UPPER,) == tuple(boundary.get_boundaries("aA"))
 

--- a/tests/convert/test_cases.py
+++ b/tests/convert/test_cases.py
@@ -13,6 +13,10 @@ def test_kebab() -> None:
     assert convert("RONNIE_JAMES_DIO", case.KEBAB) == "ronnie-james-dio"
 
 
+def test_middot() -> None:
+    assert convert("ronnie james dio", case.MIDDOT) == "ronnie·james·dio"
+
+
 def test_camel() -> None:
     assert convert("RONNIE-JAMES-DIO", case.CAMEL) == "ronnieJamesDio"
 

--- a/tests/is_case/test_cases.py
+++ b/tests/is_case/test_cases.py
@@ -17,8 +17,8 @@ def test_kebab() -> None:
 
 
 def test_middot() -> None:
-    assert is_case("ronnie·james·dio", case.KEBAB) is True
-    assert is_case("RONNIE_JAMES_DIO", case.KEBAB) is False
+    assert is_case("ronnie·james·dio", case.MIDDOT) is True
+    assert is_case("RONNIE_JAMES_DIO", case.MIDDOT) is False
 
 
 def test_camel() -> None:

--- a/tests/is_case/test_cases.py
+++ b/tests/is_case/test_cases.py
@@ -16,6 +16,11 @@ def test_kebab() -> None:
     assert is_case("RONNIE_JAMES_DIO", case.KEBAB) is False
 
 
+def test_middot() -> None:
+    assert is_case("ronnie·james·dio", case.KEBAB) is True
+    assert is_case("RONNIE_JAMES_DIO", case.KEBAB) is False
+
+
 def test_camel() -> None:
     assert is_case("ronnieJamesDio", case.CAMEL) is True
     assert is_case("RONNIE-JAMES-DIO", case.CAMEL) is False

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -111,7 +111,7 @@ SPACE: Final[Boundary] = Boundary.from_delimiter(" ")
 """
 
 INTERPUNCT: Final[Boundary] = Boundary.from_delimiter("·")
-"""Splits on `-`, consuming the character on segmentation.
+"""Splits on `·`, consuming the character on segmentation.
 
 **Unreleased**.
 """

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -70,7 +70,7 @@ class Boundary:
 
         This is a helper method that can be used to create simple boundaries such as
         [`UNDERSCORE`][textcase.boundary.UNDERSCORE], [`HYPHEN`][textcase.boundary.HYPHEN],
-        or [`SPACE`][textcase.boundary.SPACE].
+        [`SPACE`][textcase.boundary.SPACE], or [`INTERPUNCT`][textcase.boundary.INTERPUNCT].
 
         **Unreleased.**
 

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -8,6 +8,7 @@ __all__ = [
     "UNDERSCORE",
     "HYPHEN",
     "SPACE",
+    "INTERPUNCT",
     "LOWER_UPPER",
     "UPPER_LOWER",
     "ACRONYM",

--- a/textcase/boundary.py
+++ b/textcase/boundary.py
@@ -105,9 +105,15 @@ HYPHEN: Final[Boundary] = Boundary.from_delimiter("-")
 """
 
 SPACE: Final[Boundary] = Boundary.from_delimiter(" ")
-"""Splits on space, consuming the character on segmentation.
+"""Splits on ` `, consuming the character on segmentation.
 
 **Added in version:** [`0.2.0`](https://zobweyt.github.io/textcase/changelog/#020-2025-04-01)
+"""
+
+INTERPUNCT: Final[Boundary] = Boundary.from_delimiter("·")
+"""Splits on `-`, consuming the character on segmentation.
+
+**Unreleased**.
 """
 
 LOWER_UPPER: Final[Boundary] = Boundary(

--- a/textcase/case.py
+++ b/textcase/case.py
@@ -8,6 +8,7 @@ __all__ = [
     "SNAKE",
     "CONSTANT",
     "KEBAB",
+    "MIDDOT",
     "CAMEL",
     "PASCAL",
     "LOWER",

--- a/textcase/case.py
+++ b/textcase/case.py
@@ -25,6 +25,7 @@ from textcase.boundary import (
     DIGIT_LOWER,
     DIGIT_UPPER,
     HYPHEN,
+    INTERPUNCT,
     LOWER_DIGIT,
     LOWER_UPPER,
     SPACE,
@@ -97,6 +98,16 @@ KEBAB: Final[Case] = Case(
 """Kebab case strings are delimited by hyphens `-` and are all lowercase.
 
 **Added in version:** [`0.2.0`](https://zobweyt.github.io/textcase/changelog/#020-2025-04-01)
+"""
+
+MIDDOT: Final[Case] = Case(
+    boundaries=(INTERPUNCT,),
+    pattern=lower,
+    delimiter="·",
+)
+"""Middot case strings are delimited by interpuncts `·` and are all lowercase.
+
+**Unreleased.**
 """
 
 CAMEL: Final[Case] = Case(


### PR DESCRIPTION
### Description

This PR adds a new `INTERPUNCT` boundary and `MIDDOT` case.

#### Example

```python
from textcase import convert, case

print(convert("ronnie james dio", case.MIDDOT))  # ronnie·james·dio

print(is_case("ronnie·james·dio", case.MIDDOT))  # True
print(is_case("RONNIE_JAMES_DIO", case.MIDDOT))  # False
```

### Changes

#### Features <!-- omit in toc -->

- add `INTERPUNCT` boundary ([`617376d`](https://github.com/zobweyt/textcase/commit/617376d6f9991889434d1eb7e55965d3683c7682))
- add `MIDDOT` case ([`c313669`](https://github.com/zobweyt/textcase/commit/c313669c11792372f2ec50c5e350610b9df6b3c6))
- add `MIDDOT` case to `textcase.case.__all__` ([`04b516c`](https://github.com/zobweyt/textcase/commit/04b516c5e65e92846d473138a5065ebccab62f25))
- add `INTERPUNCT` boundary to `textcase.boundary.__all__` ([`d274402`](https://github.com/zobweyt/textcase/commit/d274402fc4d941f7c4e6386dccd43b52317bc813))

#### Testing <!-- omit in toc -->

- add `INTERPUNCT` boundary test case ([`1aa79d2`](https://github.com/zobweyt/textcase/commit/1aa79d24e4d81348ff7469c5f20e84072c5eba81))
- add `MIDDOT` case convert test case ([`318fe98`](https://github.com/zobweyt/textcase/commit/318fe98a0398bac93ad11a763059ddd0813f5767))
- add `MIDDOT` case is_case test case ([`54af0c6`](https://github.com/zobweyt/textcase/commit/54af0c6a2ed0544b90eb16557ef916b542bf2293))

#### Documentation <!-- omit in toc -->

- add `MIDDOT` case examples ([`3f560db`](https://github.com/zobweyt/textcase/commit/3f560dbf97ab368e675522136a60d73c005433b9))
- add `INTERPUNCT` boundary as an example to `Boundary.from_delimiter` docstring ([`06f62b1`](https://github.com/zobweyt/textcase/commit/06f62b1ce97d1c09f3b0924aa44ad0a7edbf0efd))

### Related

- Closes #2
