### PR TITLE
fix: use `@classmethod` instead of `@staticmethod` and `TypeVar` in `Boundary.from_delimiter` for proper inheritance typing

### DIFF
--- a/src/textcase/__init__.py
+++ b/src/textcase/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "sentence",
     "snake",
     "SPACE",
+    "TBoundary",
     "title",
     "UNDERSCORE",
     "UPPER_DIGIT",
@@ -28,7 +29,9 @@ __all__ = [
 
 from dataclasses import dataclass
 from string import punctuation
-from typing import Callable, Iterable
+from typing import Callable, Iterable, TypeVar
+
+TBoundary = TypeVar("TBoundary", bound="Boundary")
 
 
 @dataclass(frozen=True)
@@ -64,8 +67,8 @@ class Boundary:
     length: int = 0
     """The length of the boundary. This is the number of graphemes that are removed when splitting."""
 
-    @staticmethod
-    def from_delimiter(delimiter: str) -> "Boundary":
+    @classmethod
+    def from_delimiter(cls: type[TBoundary], delimiter: str) -> TBoundary:
         """Create a new boundary instance from a delimiter string.
 
         This method makes it easier to create basic boundaries like `UNDERSCORE`, `HYPHEN`, `SPACE`, and `INTERPUNCT`.
@@ -92,7 +95,7 @@ class Boundary:
             >>> DOT.length
             1
         """
-        return Boundary(match=lambda s: s.startswith(delimiter), length=len(delimiter))
+        return cls(match=lambda s: s.startswith(delimiter), length=len(delimiter))
 
 
 UNDERSCORE = Boundary.from_delimiter("_")

--- a/tests/boundaries/test_boundary_from_delimiter.py
+++ b/tests/boundaries/test_boundary_from_delimiter.py
@@ -50,3 +50,12 @@ def test_dot_start() -> None:
 def test_dot_length() -> None:
     """Has a length value of 1."""
     assert DOT.length == 1
+
+
+def test_return_type_of_custom_subclass() -> None:
+    "Verify that method returns an instance of the custom subclass."
+
+    class CustomBoundary(Boundary):
+        pass
+
+    assert type(CustomBoundary.from_delimiter(".")).__name__ == CustomBoundary.__name__


### PR DESCRIPTION
### Description

This PR fixes the return type of `Boundary.from_delimiter` when called from a custom subclass.

### Changes

- fix: use `@classmethod` instead of `@staticmethod` and `TypeVar` in `Boundary.from_delimiter` for proper inheritance typing (b49b52b)
- test: add Boundary.from_delimiter test case for verifying the return type of a custom subclass of `Boundary` (bf5b9cc)

### Related

- Closes #14

